### PR TITLE
Add repository field for market place to catch up.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,9 @@
         "mocha": "^2.3.3",
         "@types/node": "^6.0.40",
         "@types/mocha": "^2.2.32"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/infinity1207/angular2-switcher"
     }
 }


### PR DESCRIPTION
As this field is not filled, the marketplace doesn't add automatic link, PR / Issues number to the description.