### PR TITLE
fix: remove typo in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "configuration": {
       "title": "Side by side",
       "properties": {
-        "angular2-swithcer.openSideBySide": {
+        "angular2-switcher.openSideBySide": {
           "type": "boolean",
           "default": false,
           "description": "Open files side by side to Angular Component Typescript file."


### PR DESCRIPTION
Change FROM `angular2-swithcer.openSideBySide `TO `angular2-switcher.openSideBySide`.