### PR TITLE
Support filename.ng.html convention

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -16,6 +16,9 @@ export function getFileNameWithoutExtension(path: string) {
         if (parts[parts.length - 1] === "spec") {
             parts.pop();
         }
+        if (parts[parts.length - 1] === "ng") {
+            parts.pop();
+        }
     }
     return parts.join(".");
 }


### PR DESCRIPTION
Our project uses filename.ng.html format (instead of filename.html supported by the extension), and without this fix the extension can't be used to switch from an html file to the css or ts.

The other side of the change in extension.ts is not required due to vscode fuzzy open logic.