### PR TITLE
allow reusing of views

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,12 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
-    },
-    "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
-    },
-    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+  "files.exclude": {
+    "out": false // set this to true to hide the "out" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "out": true // set this to false to include "out" folder in search results
+  },
+  // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+  "typescript.tsc.autoDetect": "off",
+  "editor.formatOnSave": false
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Open files side by side."
+					},
+          "reuseView": {
+						"type": "boolean",
+						"default": false,
+						"description": "Reuse opened view"
 					}
 				}
 			},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { TemplateDefinitionProvider } from "./template-definition-provider";
 
 let previous = "";
 let openSideBySide = vscode.workspace.getConfiguration("angular2-switcher").get<boolean>("openSideBySide")!;
+let reuseView = vscode.workspace.getConfiguration("angular2-switcher").get<boolean>("reuseView")!;
 let styleFormats = vscode.workspace.getConfiguration("angular2-switcher").get<string[]>("styleFormats")!;
 let templateFormats = vscode.workspace.getConfiguration("angular2-switcher").get<string[]>("templateFormats")!;
 
@@ -153,6 +154,11 @@ async function openCorrespondingFile(fileNameWithoutExtension: string, ...format
 
     for (let index = 0; index < formats.length; index++) {
         const fileName = `${fileNameWithoutExtension}${formats[index]}`;
+        const textEditor = vscode.window.visibleTextEditors.find(textDocument => textDocument.document.fileName === fileName);
+        if(reuseView && !!textEditor) {
+          await vscode.window.showTextDocument(textEditor.document, textEditor.viewColumn);
+          break;
+        }
         var succ = await openFile(fileName);
         if (succ) {
             break;


### PR DESCRIPTION
When switching between styles, template, typescript and having the different files open in different views/groups, you can now configure angular2-switcher to jump between the visible editors and not open a new tab in the current group.