### PR TITLE
Update config on change, add revealIfOpen to contributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"icon": "images/logo.png",
 	"displayName": "angular2-switcher",
 	"description": "Easily navigate to `typescript`|`template`|`style` in angular2 project.",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"engines": {
 		"vscode": "^1.41.0"
 	},
@@ -69,7 +69,7 @@
 						"default": false,
 						"description": "Open files side by side."
 					},
-          "reuseView": {
+					"reuseView": {
 						"type": "boolean",
 						"default": false,
 						"description": "Reuse opened view"
@@ -100,6 +100,16 @@
 							".html"
 						],
 						"description": "The order of angular2-switcher find corresponding template file."
+					}
+				}
+			},
+      {
+				"title": "Reveal if open",
+				"properties": {
+					"angular2-switcher.revealIfOpen": {
+						"type": "boolean",
+						"default": false,
+						"description": "Open editor if file is already open"
 					}
 				}
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,12 +3,29 @@ import { fileIs, getFileNameWithoutExtension } from "./common";
 import { TemplateDefinitionProvider } from "./template-definition-provider";
 
 let previous = "";
-let openSideBySide = vscode.workspace.getConfiguration("angular2-switcher").get<boolean>("openSideBySide")!;
-let reuseView = vscode.workspace.getConfiguration("angular2-switcher").get<boolean>("reuseView")!;
-let styleFormats = vscode.workspace.getConfiguration("angular2-switcher").get<string[]>("styleFormats")!;
-let templateFormats = vscode.workspace.getConfiguration("angular2-switcher").get<string[]>("templateFormats")!;
+
+let openSideBySide: boolean;
+let revealIfOpen: boolean;
+let styleFormats: string[];
+let templateFormats: string[];
+
+function updateConfig()
+{
+  openSideBySide = vscode.workspace.getConfiguration("angular2-switcher").get<boolean>("openSideBySide")!;
+  revealIfOpen = vscode.workspace.getConfiguration("angular2-switcher").get<boolean>("revealIfOpen")!;
+  styleFormats = vscode.workspace.getConfiguration("angular2-switcher").get<string[]>("styleFormats")!;
+  templateFormats = vscode.workspace.getConfiguration("angular2-switcher").get<string[]>("templateFormats")!;  
+}
+
+updateConfig();
 
 export function activate(context: vscode.ExtensionContext) {
+  
+    let updateConfigSub = vscode.workspace.onDidChangeConfiguration(() => {
+      updateConfig();
+    });
+    context.subscriptions.push(updateConfigSub);
+    
     let switchTemplateCommand = vscode.commands.registerCommand('extension.switchTemplate', switchTemplate);
     context.subscriptions.push(switchTemplateCommand);
 
@@ -155,7 +172,7 @@ async function openCorrespondingFile(fileNameWithoutExtension: string, ...format
     for (let index = 0; index < formats.length; index++) {
         const fileName = `${fileNameWithoutExtension}${formats[index]}`;
         const textEditor = vscode.window.visibleTextEditors.find(textDocument => textDocument.document.fileName === fileName);
-        if(reuseView && !!textEditor) {
+        if(revealIfOpen && !!textEditor) {
           await vscode.window.showTextDocument(textEditor.document, textEditor.viewColumn);
           break;
         }


### PR DESCRIPTION
- Add a subscription to update the extension configuration on change.
- Expose the setting **revealIfOpen** (previously named **reuseView**) in contributes (package.json) to make it available (the setting was present the implementation but missing in contributes)
- Rename **reuseView** setting to **revealIfOpen** setting to use the same settingsname that vscode uses internally